### PR TITLE
Add static-save doco from KirstieJane 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ To run, simply open `index.html`.
 To run the linter install the dependancies using `npm install` and then run the linter `npm run lint`
 
 
-## How to save a static version of the js-hatrack page
+## How to save a static version of the hatrack page
 
-* **Problem**: At the moment you can only see the contributors for a github repo via https://labhr.github.io/js-hatrack/ if you're logged into GitHub (because the information is pulled in real time to create the webpage and you need to be verified by GitHub to be allowed to send enough requests to compile the information). I'd like to host a page on my website that means ***anyone*** can see who has contributed without requiring the buy in of creating a GitHub account.
+* **Problem**: At the moment you can only see the contributors for a github repo via https://labhr.github.io/hatrack/ if you're logged into GitHub (because the information is pulled in real time to create the webpage and you need to be verified by GitHub to be allowed to send enough requests to compile the information). I'd like to host a page on my website that means ***anyone*** can see who has contributed without requiring the buy in of creating a GitHub account.
 
-* **Solution**: A project member logs in with GitHub and create the lovely looking page via https://labhr.github.io/js-hatrack/ then saves a non-dynamic copy using the [Scrapbook](https://addons.mozilla.org/en-US/firefox/addon/scrapbook/) Firefox add on.
+* **Solution**: A project member logs in with GitHub and create the lovely looking page via https://labhr.github.io/hatrack/ then saves a non-dynamic copy using the [Scrapbook](https://addons.mozilla.org/en-US/firefox/addon/scrapbook/) Firefox add on.
 
 **Instructions**
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,29 @@ To run, simply open `index.html`.
 
 To run the linter install the dependancies using `npm install` and then run the linter `npm run lint`
 
+
+## How to save a static version of the js-hatrack page
+
+* **Problem**: At the moment you can only see the contributors for a github repo via https://labhr.github.io/js-hatrack/ if you're logged into GitHub (because the information is pulled in real time to create the webpage and you need to be verified by GitHub to be allowed to send enough requests to compile the information). I'd like to host a page on my website that means ***anyone*** can see who has contributed without requiring the buy in of creating a GitHub account.
+
+* **Solution**: A project member logs in with GitHub and create the lovely looking page via https://labhr.github.io/js-hatrack/ then saves a non-dynamic copy using the [Scrapbook](https://addons.mozilla.org/en-US/firefox/addon/scrapbook/) Firefox add on.
+
+**Instructions**
+
+* Install the [Scrapbook](https://addons.mozilla.org/en-US/firefox/addon/scrapbook/) Firefox add on
+* Create the Lets Build a Hat Rack contributers page for your project:
+  * Go to https://labhr.github.io/js-hatrack/
+  * Login with GitHub 
+  * Enter the repository name
+  * Click go!
+* Save the page to your local machine using Scrapbook (click `alt` to see the Firefox browser menu). * Copy this folder (which is helpfully named with the date and time that you downloaded it) to your website's folder.
+
+**And you're done!** :tada: :sparkles: 
+
+Here's an example: http://kirstiejane.github.io/STEMMRoleModels/octohatrack_output/Scrapbook_20160317092940/index.html
+
+
+
 TODO
 ----
 


### PR DESCRIPTION
Over in https://github.com/LABHR/octohatrack/issues/75#issuecomment-197795221, @KirstieJane gives us some wonderful userland doco detailing how to save a copy of the output of hatrack. 

 @leesdolphin - I'm ok for this to be added to the doco for now, but is there a way to have a nice export of the page native to the app itself? This is beyond my JS ability, though I could hack something together, I'm sure.